### PR TITLE
Use correct command to checkout a specific tag from git.

### DIFF
--- a/mopytools/util.py
+++ b/mopytools/util.py
@@ -281,7 +281,10 @@ def update_cmd(project=None, channel="prod", specific_tag=False,
                 print('Unknown tag or revision: %s' % rev)
                 sys.exit(1)
 
-            return '%s -r "%s"' % (cmd, rev)
+            if is_git():
+                return '%s "%s"' % (cmd, rev)
+            else:
+                return '%s -r "%s"' % (cmd, rev)
 
     return cmd
 


### PR DESCRIPTION
Previously this would try to use "git checkout -r <tagname>", which
fails.
