### PR TITLE
Don't pass an empty --extra-index-url through to pip.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 3.4 - ?
 =======
 
-?
+- don't pass an empty --extra-index-url through to pip.
 
 
 3.3 - 2012-06-29

--- a/mopytools/build_app.py
+++ b/mopytools/build_app.py
@@ -66,9 +66,6 @@ def main():
 
 @step('Building the app')
 def _buildapp(channel, deps, force, timeout, verbose, index, extras, cache):
-    if extras is None:
-        extras = ''
-
     # check the environ
     name, specific_tags = get_environ_info(deps)
 
@@ -188,11 +185,12 @@ def build_external_deps(channel, index, extras, timeout=300, verbose=False,
             inc += 1
         os.rename('build', root + str(inc))
 
+    pip = '%s install -i %s -U -r %s'
+    args = (PIP, index, reqname)
     if cache is not None:
-        pip = ('%s install --download-cache %s -i %s --extra-index-url '
-               '%s -U -r %s')
-        run(pip % (PIP, cache, index, extras, reqname), timeout, verbose)
-    else:
-        pip = ('%s install -i %s --extra-index-url '
-               '%s -U -r %s')
-        run(pip % (PIP, index, extras, reqname), timeout, verbose)
+        pip += ' --download-cache %s'
+        args += (cache,)
+    if extras is not None:
+        pip += ' --extra-index-url %s'
+        args += (extras,)
+    run(pip % args, timeout, verbose)


### PR DESCRIPTION
If the PYPIEXTRAS env var is empty, we currently generate a `pip` command-line like this:

```
pip install --extra-index-url  -U -r dev-reqs.txt
```

This means that it will treat "-U" as an extra index url.  Old versions of pip didn't seem to choke on this, but the recent 1.5 release throws an error when it tries to open that as a URL.

This patch elides the option if it's empty.  I'm going to r=myself and push a new version of MoPyTools since this is breaking builds in the wild.
